### PR TITLE
feat(main): add webhook test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: 🧪 E2E Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  job0:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.23.x
+
+      - name: build
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-
+	@cp -rf config/crd/bases/* deploy/charts/automq-operator/crds/
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
@@ -62,7 +62,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... --ginkgo.v -v --ginkgo.trace
 
 ##@ Build
 
@@ -163,11 +163,8 @@ $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 
-.PHONY: crd
-crd: manifests generate kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	@cp -rf config/crd/bases/* deploy/charts/automq-operator/crds/
-
 info:
 	@cat deploy/charts/automq-operator/values.yaml
 	@cat deploy/charts/automq-operator/Chart.yaml
 	@cat deploy/images/shim/image.txt
+

--- a/api/v1beta1/automq_types.go
+++ b/api/v1beta1/automq_types.go
@@ -120,8 +120,7 @@ type BrokerSpec struct {
 type MetricsSpec struct {
 	// Enable is the flag to enable the metrics
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=prometheus;otlp
-	// +kubebuilder:default=prometheus
+	// +kubebuilder:default=true
 	Enable bool `json:"enable,omitempty"`
 	// ImportDashboard is the flag to import the dashboard.
 	// +kubebuilder:default=true

--- a/api/v1beta1/automq_webhook.go
+++ b/api/v1beta1/automq_webhook.go
@@ -33,8 +33,6 @@ func (r *AutoMQ) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 //+kubebuilder:webhook:path=/mutate-infra-cuisongliu-github-com-v1beta1-automq,mutating=true,failurePolicy=fail,sideEffects=None,groups=infra.cuisongliu.github.com,resources=automqs,verbs=create;update,versions=v1beta1,name=mautomq.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Defaulter = &AutoMQ{}
@@ -42,8 +40,30 @@ var _ webhook.Defaulter = &AutoMQ{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *AutoMQ) Default() {
 	automqlog.Info("default", "name", r.Name)
-
-	// TODO(user): fill in your defaulting logic.
+	if r.Spec.Image == "" {
+		r.Spec.Image = DefaultImageName
+	}
+	if r.Spec.S3.Region == "" {
+		r.Spec.S3.Region = "us-east-1"
+	}
+	if r.Spec.ClusterID == "" {
+		r.Spec.ClusterID = "rZdE0DjZSrqy96PXrMUZVw"
+	}
+	if r.Spec.S3.Bucket == "" {
+		r.Spec.S3.Bucket = "automq"
+	}
+	if r.Spec.Controller.JVMOptions == nil {
+		r.Spec.Controller.JVMOptions = []string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m"}
+	}
+	if r.Spec.Controller.Replicas == 0 {
+		r.Spec.Controller.Replicas = 1
+	}
+	if r.Spec.Broker.JVMOptions == nil {
+		r.Spec.Broker.JVMOptions = []string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m", "-XX:MaxDirectMemorySize=1G"}
+	}
+	if r.Spec.Broker.Replicas == 0 {
+		r.Spec.Broker.Replicas = 1
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/api/v1beta1/images.go
+++ b/api/v1beta1/images.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+package v1beta1
 
 const (
 	DefaultImageName = "automqinc/automq:1.2.0-rc1"

--- a/config/crd/bases/infra.cuisongliu.github.com_automqs.yaml
+++ b/config/crd/bases/infra.cuisongliu.github.com_automqs.yaml
@@ -554,11 +554,8 @@ spec:
                 description: Metrics is the metrics configuration for the AutoMQ
                 properties:
                   enable:
-                    default: prometheus
+                    default: true
                     description: Enable is the flag to enable the metrics
-                    enum:
-                    - prometheus
-                    - otlp
                     type: boolean
                   importDashboard:
                     default: true

--- a/deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml
+++ b/deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml
@@ -155,12 +155,8 @@ spec:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  default: ""
                                   description: |-
                                     Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
@@ -221,12 +217,8 @@ spec:
                                     be a valid secret key.
                                   type: string
                                 name:
-                                  default: ""
                                   description: |-
                                     Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
@@ -272,12 +264,6 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
-                              type: string
-                            request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -418,12 +404,8 @@ spec:
                                   description: The key to select.
                                   type: string
                                 name:
-                                  default: ""
                                   description: |-
                                     Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
@@ -484,12 +466,8 @@ spec:
                                     be a valid secret key.
                                   type: string
                                 name:
-                                  default: ""
                                   description: |-
                                     Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 optional:
@@ -536,12 +514,6 @@ spec:
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
                               type: string
-                            request:
-                              description: |-
-                                Request is the name chosen for a request in the referenced claim.
-                                If empty, everything from the claim is made available, otherwise
-                                only the result of this request.
-                              type: string
                           required:
                           - name
                           type: object
@@ -582,11 +554,8 @@ spec:
                 description: Metrics is the metrics configuration for the AutoMQ
                 properties:
                   enable:
-                    default: prometheus
+                    default: true
                     description: Enable is the flag to enable the metrics
-                    enum:
-                    - prometheus
-                    - otlp
                     type: boolean
                   importDashboard:
                     default: true

--- a/deploy/charts/automq-operator/templates/webhook.yaml
+++ b/deploy/charts/automq-operator/templates/webhook.yaml
@@ -66,7 +66,6 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
-          - DELETE
         resources:
           - automqs
     sideEffects: None

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -18,11 +18,10 @@ package main
 
 import (
 	"fmt"
+	"github.com/cuisongliu/automq-operator/api/v1beta1"
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/cuisongliu/automq-operator/internal/controller"
 )
 
 func main() {
@@ -33,7 +32,7 @@ func main() {
 	imageName := os.Args[1]
 	fmt.Printf("image name is %s", imageName)
 	_ = os.MkdirAll("deploy/images/shim", 0755)
-	_ = os.WriteFile("deploy/images/shim/image.txt", []byte(controller.DefaultImageName), 0755)
+	_ = os.WriteFile("deploy/images/shim/image.txt", []byte(v1beta1.DefaultImageName), 0755)
 	cmd1 := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\image: %s' deploy/charts/automq-operator/values.yaml", imageName)
 	if err := execCmd("bash", "-c", cmd1); err != nil {
 		fmt.Printf("execCmd error %v", err)


### PR DESCRIPTION
This pull request includes several changes to the `api`, `Makefile`, and configuration files to improve testing, webhook setup, and default values. The most important changes include adding an E2E test workflow, updating default values and validation rules, and enhancing the webhook setup.

### CI/CD Improvements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R25): Added an E2E test workflow that runs on pushes and pull requests to the `main` branch.

### Makefile Enhancements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L50-R50): Added a step to copy CRD bases to the deployment charts directory in the `manifests` target.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L65-R65): Updated the `test` target to include additional flags for verbose and trace output.

### API and Webhook Updates:
* [`api/v1beta1/automq_types.go`](diffhunk://#diff-8fb9499d797e9e6073eb594990a409c444112ce192f26acc4cb88e16bbc8c537L123-R123): Changed the default value for the `Enable` field in `MetricsSpec` from `prometheus` to `true`.
* [`api/v1beta1/automq_webhook.go`](diffhunk://#diff-c41c3e347cf67cb21a4b585802fd2ec0ddbe8c08fa036404b11e7c16e3554a68L36-R66): Implemented defaulting logic for various fields in the `AutoMQ` struct.
* [`api/v1beta1/webhook_suite_test.go`](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36R29-R31): Added tests for default values and included additional API schemes. [[1]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36R29-R31) [[2]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36R63-R87) [[3]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36L68-R96) [[4]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36R108-R110) [[5]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36L95-R129) [[6]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36L138)

### Configuration Changes:
* [`config/crd/bases/infra.cuisongliu.github.com_automqs.yaml`](diffhunk://#diff-e3ffe2350b5eeb12838983f35561eb4882fe76f83687a6f0781f7f64b230f21fL557-L561): Updated the default value for the `enable` field in the `Metrics` configuration to `true`.
* [`deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml`](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L158-L163): Removed default values for `name` fields and unnecessary `request` fields. [[1]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L158-L163) [[2]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L224-L229) [[3]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L276-L281) [[4]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L421-L426) [[5]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L487-L492) [[6]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L539-L544) [[7]](diffhunk://#diff-3d04b28517dbf6c68ffc5fbb51b14c54064d3b0816fbc46d223e10b6a2be60f4L585-L589)

### Codebase Simplification:
* [`api/v1beta1/images.go`](diffhunk://#diff-7aaf4df82f9823794762e0308c52f2ddd5285a02a819a595f235f7d14e680c55L17-R17): Renamed from `internal/controller/images.go` and updated the package name to `v1beta1`.
* [`gen/gen.go`](diffhunk://#diff-f18b4bb9cf8a60ec40543e036c8e0f25a8f2e97d9c45108748eec629f0fb4c57R21-L25): Updated references to use `v1beta1.DefaultImageName` instead of `controller.DefaultImageName`. [[1]](diffhunk://#diff-f18b4bb9cf8a60ec40543e036c8e0f25a8f2e97d9c45108748eec629f0fb4c57R21-L25) [[2]](diffhunk://#diff-f18b4bb9cf8a60ec40543e036c8e0f25a8f2e97d9c45108748eec629f0fb4c57L36-R35)