### PR TITLE
feat(main): add webhook test

### DIFF
--- a/api/v1beta1/automq_types.go
+++ b/api/v1beta1/automq_types.go
@@ -134,10 +134,8 @@ type AutoMQSpec struct {
 	S3 S3Spec `json:"s3,omitempty"`
 	// ClusterID is the ID of the cluster. Default is "rZdE0DjZSrqy96PXrMUZVw"
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:default=rZdE0DjZSrqy96PXrMUZVw
 	ClusterID string `json:"clusterID,omitempty"`
 	// Image is the image of the AutoMQ
-	// +kubebuilder:validation:default=automqinc/automq:1.2.0-rc1
 	Image string `json:"image,omitempty"`
 	// Metrics is the metrics configuration for the AutoMQ
 	Metrics MetricsSpec `json:"metrics,omitempty"`

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -77,44 +77,65 @@ func initAutoMQ() *AutoMQ {
 }
 
 var _ = Describe("Default", func() {
-	It("Default ImageName", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.Image).To(Equal(DefaultImageName))
+	Context("Default Webhook", func() {
+		BeforeEach(func() {
+			aq := initAutoMQ()
+			_ = k8sClient.Delete(context.Background(), aq)
+		})
+		It("Default ImageName", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.Image).To(Equal(DefaultImageName))
+		})
+		It("Default Region", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.S3.Region).To(Equal("us-east-1"))
+		})
+		It("Default ClusterID", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.ClusterID).To(Equal("rZdE0DjZSrqy96PXrMUZVw"))
+			err = k8sClient.Delete(context.Background(), aq)
+			Expect(err).To(BeNil())
+		})
+		It("Default Bucket", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.S3.Bucket).To(Equal("automq"))
+		})
+		It("Default Replicas", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.Controller.Replicas).To(Equal(int32(1)))
+			Expect(aq.Spec.Broker.Replicas).To(Equal(int32(1)))
+		})
+		It("Default JVM", func() {
+			aq := initAutoMQ()
+			err := k8sClient.Create(context.Background(), aq)
+			Expect(err).To(BeNil())
+			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
+			Expect(err).To(BeNil())
+			Expect(aq.Spec.Controller.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m"}))
+			Expect(aq.Spec.Broker.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m", "-XX:MaxDirectMemorySize=1G"}))
+		})
 	})
-	It("Default Region", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.S3.Region).To(Equal("us-east-1"))
-	})
-	It("Default ClusterID", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.ClusterID).To(Equal("rZdE0DjZSrqy96PXrMUZVw"))
-	})
-	It("Default Bucket", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.S3.Bucket).To(Equal("automq"))
-	})
-	It("Default Replicas", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.Controller.Replicas).To(Equal(1))
-		Expect(aq.Spec.Broker.Replicas).To(Equal(1))
-	})
-	It("Default JVM", func() {
-		aq := initAutoMQ()
-		err := k8sClient.Create(context.Background(), aq)
-		Expect(err).To(BeNil())
-		Expect(aq.Spec.Controller.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m"}))
-		Expect(aq.Spec.Broker.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m", "-XX:MaxDirectMemorySize=1G"}))
-	})
+
 })
 
 var _ = BeforeSuite(func() {

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -77,11 +77,43 @@ func initAutoMQ() *AutoMQ {
 }
 
 var _ = Describe("Default", func() {
-	It("ImageName", func() {
+	It("Default ImageName", func() {
 		aq := initAutoMQ()
 		err := k8sClient.Create(context.Background(), aq)
 		Expect(err).To(BeNil())
 		Expect(aq.Spec.Image).To(Equal(DefaultImageName))
+	})
+	It("Default Region", func() {
+		aq := initAutoMQ()
+		err := k8sClient.Create(context.Background(), aq)
+		Expect(err).To(BeNil())
+		Expect(aq.Spec.S3.Region).To(Equal("us-east-1"))
+	})
+	It("Default ClusterID", func() {
+		aq := initAutoMQ()
+		err := k8sClient.Create(context.Background(), aq)
+		Expect(err).To(BeNil())
+		Expect(aq.Spec.ClusterID).To(Equal("rZdE0DjZSrqy96PXrMUZVw"))
+	})
+	It("Default Bucket", func() {
+		aq := initAutoMQ()
+		err := k8sClient.Create(context.Background(), aq)
+		Expect(err).To(BeNil())
+		Expect(aq.Spec.S3.Bucket).To(Equal("automq"))
+	})
+	It("Default Replicas", func() {
+		aq := initAutoMQ()
+		err := k8sClient.Create(context.Background(), aq)
+		Expect(err).To(BeNil())
+		Expect(aq.Spec.Controller.Replicas).To(Equal(1))
+		Expect(aq.Spec.Broker.Replicas).To(Equal(1))
+	})
+	It("Default JVM", func() {
+		aq := initAutoMQ()
+		err := k8sClient.Create(context.Background(), aq)
+		Expect(err).To(BeNil())
+		Expect(aq.Spec.Controller.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m"}))
+		Expect(aq.Spec.Broker.JVMOptions).To(Equal([]string{"-Xms1g", "-Xmx1g", "-XX:MetaspaceSize=96m", "-XX:MaxDirectMemorySize=1G"}))
 	})
 })
 


### PR DESCRIPTION
This pull request introduces several changes to the `AutoMQ` Kubernetes custom resource definition, focusing on validation logic, default values, and test enhancements. The key changes include removing default values from the struct tags, adding validation logic, and enhancing the test suite.

### Validation and Default Values:

* Removed default values from `ClusterID` and `Image` fields in `AutoMQSpec` struct in `api/v1beta1/automq_types.go`.
* Added validation logic to ensure required fields are set and certain fields remain immutable during updates in `api/v1beta1/automq_webhook.go`. [[1]](diffhunk://#diff-c41c3e347cf67cb21a4b585802fd2ec0ddbe8c08fa036404b11e7c16e3554a68L77-R103) [[2]](diffhunk://#diff-c41c3e347cf67cb21a4b585802fd2ec0ddbe8c08fa036404b11e7c16e3554a68R114-R133)

### Test Enhancements:

* Enhanced the test suite to include tests for default values and immutability checks in `api/v1beta1/webhook_suite_test.go`.

### Minor Changes:

* Added the `fmt` package import in `api/v1beta1/automq_webhook.go`.
* Added the `errors` package import in `api/v1beta1/webhook_suite_test.go`.