### PR TITLE
test(sealos): e2e test for sealos

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,3 +39,39 @@ jobs:
           DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/automq-operator
         run: |
           IMG=${DOCKER_REPO}:latest make docker-buildx
+
+  job1:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.23.x
+
+      - name: Verify sealos
+        run: |
+          wget -q https://github.com/labring/sealos/releases/download/v4.3.7/sealos_4.3.7_linux_amd64.tar.gz
+          tar -zxvf sealos_4.3.7_linux_amd64.tar.gz sealos
+          sudo chmod a+x sealos
+          sudo mv sealos /usr/bin/
+          sudo sealos version
+      - name: build
+        run: |
+          go run gen/gen.go ghcr.io/${{ github.repository_owner }}/automq-operator:latest && make info
+          cd deploy
+          sudo sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_TOKEN }} --debug ghcr.io
+          IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/automq-operator-sealos:latest"
+          sudo sealos build -t "${IMAGE_NAME}"-amd64 --platform linux/amd64 .
+          sudo sealos build -t "${IMAGE_NAME}"-arm64 --platform linux/arm64 .
+          sudo sealos push "${IMAGE_NAME}"-amd64
+          sudo sealos push "${IMAGE_NAME}"-arm64
+          sudo sealos images
+          sudo sealos manifest create "${IMAGE_NAME}"
+          sudo sealos manifest add "$IMAGE_NAME" docker://"$IMAGE_NAME-amd64"
+          sudo sealos manifest add "$IMAGE_NAME" docker://"$IMAGE_NAME-arm64"
+          sudo sealos manifest push --all "$IMAGE_NAME" docker://"$IMAGE_NAME" && echo "$IMAGE_NAME push success"
+          sudo sealos images
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Verify sealos
         run: |
-          wget https://github.com/labring/sealos/releases/download/v4.3.7/sealos_4.3.7_linux_amd64.tar.gz
+          wget -q https://github.com/labring/sealos/releases/download/v4.3.7/sealos_4.3.7_linux_amd64.tar.gz
           tar -zxvf sealos_4.3.7_linux_amd64.tar.gz sealos
           sudo chmod a+x sealos
           sudo mv sealos /usr/bin/
@@ -55,3 +55,27 @@ jobs:
       - name: build
         run: |
           sudo make e2e
+
+  job2:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.23.x
+
+      - name: Verify sealos
+        run: |
+          wget -q https://github.com/labring/sealos/releases/download/v4.3.7/sealos_4.3.7_linux_amd64.tar.gz
+          tar -zxvf sealos_4.3.7_linux_amd64.tar.gz sealos
+          sudo chmod a+x sealos
+          sudo mv sealos /usr/bin/
+          sudo sealos version
+      - name: build
+        run: |
+          go run gen/gen.go ghcr.io/${{ github.repository_owner }}/automq-operator:latest && make info
+          cd deploy
+          sudo sealos build -t ghcr.io/${{ github.repository_owner }}/automq-operator-sealos:latest .

--- a/.github/workflows/update_version_config.yml
+++ b/.github/workflows/update_version_config.yml
@@ -21,7 +21,7 @@ jobs:
               vPrefix = true
               releaseBranch = main
               versionFile = .tagpr
-              command = go run gen/gen.go ghcr.io/cuisongliu/automq-operator:${{ github.event.inputs.version }} && make info
+              command = go run gen/gen.go ghcr.io/${{ github.repository_owner }}/automq-operator:${{ github.event.inputs.version }} && make info
               release = false
               changelog = true
           EOF

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
+test: fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./api/... --ginkgo.v -v --ginkgo.trace
 
 ##@ Build
@@ -169,5 +169,5 @@ info:
 	@cat deploy/images/shim/image.txt
 
 .PHONY: e2e
-e2e: manifests generate fmt vet envtest ## Run tests.
+e2e: fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./e2e/... --ginkgo.v -v --ginkgo.trace

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -44,6 +44,9 @@ func main() {
 		os.Exit(1)
 	}
 	shotVersion := strings.ReplaceAll(version[1], "v", "")
+	if shotVersion == "latest" {
+		shotVersion = "0.0.0"
+	}
 	cmd2 := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\version: %s' deploy/charts/automq-operator/Chart.yaml", shotVersion)
 	if err := execCmd("bash", "-c", cmd2); err != nil {
 		fmt.Printf("execCmd error %v", err)


### PR DESCRIPTION
This pull request introduces new jobs in the GitHub Actions workflows and includes several other improvements and fixes. The most important changes include adding new jobs to the CI workflows, updating commands to use the repository owner dynamically, and modifying the `Makefile` to streamline the testing process.

### CI Workflow Enhancements:
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R42-R77): Added a new job (`job1`) to build and push images using `sealos`. This job includes steps for setting up Go, verifying `sealos`, building images, and pushing them to the repository.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R58-R81): Added a new job (`job2`) similar to `job1` in `push.yml`, which includes steps for checking out the code, setting up Go, verifying `sealos`, and building images.

### Command Updates:
* [`.github/workflows/update_version_config.yml`](diffhunk://#diff-9a4869688fe7922e441c311ecd0240c2ded4e7bbd4dfb6c1ce3c76dd23d4290bL24-R24): Updated the `command` to use the dynamic repository owner for generating and building the operator image.

### Makefile Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L64-R64): Simplified the `test` and `e2e` targets by removing unnecessary dependencies on `manifests` and `generate`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L64-R64) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L172-R172)

### Code Fixes:
* [`gen/gen.go`](diffhunk://#diff-f18b4bb9cf8a60ec40543e036c8e0f25a8f2e97d9c45108748eec629f0fb4c57R47-R49): Added a condition to handle the "latest" version by setting it to "0.0.0" to avoid issues with version replacement in the `Chart.yaml` file.