### PR TITLE
test(sealos): images fix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,10 +62,10 @@ jobs:
         run: |
           go run gen/gen.go ghcr.io/${{ github.repository_owner }}/automq-operator:latest && make info
           cd deploy
-          sudo sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_TOKEN }} --debug ghcr.io
           IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/automq-operator-sealos:latest"
           sudo sealos build -t "${IMAGE_NAME}"-amd64 --platform linux/amd64 .
           sudo sealos build -t "${IMAGE_NAME}"-arm64 --platform linux/arm64 .
+          sudo sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_TOKEN }} --debug ghcr.io
           sudo sealos push "${IMAGE_NAME}"-amd64
           sudo sealos push "${IMAGE_NAME}"-arm64
           sudo sealos images

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN go mod download
 # Copy the go source
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
-COPY internal/controller/ internal/controller/
-
+COPY internal/ internal/
+COPY defaults defaults
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO

--- a/api/v1beta1/automq_webhook.go
+++ b/api/v1beta1/automq_webhook.go
@@ -18,6 +18,8 @@ package v1beta1
 
 import (
 	"fmt"
+
+	"github.com/cuisongliu/automq-operator/defaults"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -42,7 +44,7 @@ var _ webhook.Defaulter = &AutoMQ{}
 func (r *AutoMQ) Default() {
 	automqlog.Info("default", "name", r.Name)
 	if r.Spec.Image == "" {
-		r.Spec.Image = DefaultImageName
+		r.Spec.Image = defaults.DefaultImageName
 	}
 	if r.Spec.S3.Region == "" {
 		r.Spec.S3.Region = "us-east-1"

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/cuisongliu/automq-operator/defaults"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	v1 "k8s.io/api/admissionregistration/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -89,7 +91,7 @@ var _ = Describe("Default", func() {
 			Expect(err).To(BeNil())
 			err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(aq), aq)
 			Expect(err).To(BeNil())
-			Expect(aq.Spec.Image).To(Equal(DefaultImageName))
+			Expect(aq.Spec.Image).To(Equal(defaults.DefaultImageName))
 		})
 		It("Default Region", func() {
 			aq := initAutoMQ()

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/defaults/images.go
+++ b/defaults/images.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package defaults
 
 const (
 	DefaultImageName = "automqinc/automq:1.2.0-rc1"

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/cuisongliu/automq-operator/api/v1beta1"
+	"github.com/cuisongliu/automq-operator/defaults"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,7 +32,7 @@ func main() {
 	imageName := os.Args[1]
 	fmt.Printf("image name is %s", imageName)
 	_ = os.MkdirAll("deploy/images/shim", 0755)
-	_ = os.WriteFile("deploy/images/shim/image.txt", []byte(v1beta1.DefaultImageName), 0755)
+	_ = os.WriteFile("deploy/images/shim/image.txt", []byte(defaults.DefaultImageName), 0755)
 	cmd1 := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\image: %s' deploy/charts/automq-operator/values.yaml", imageName)
 	if err := execCmd("bash", "-c", cmd1); err != nil {
 		fmt.Printf("execCmd error %v", err)


### PR DESCRIPTION
This pull request includes several changes to improve the organization and functionality of the `automq-operator` project. The most important changes involve moving default values to a new package, updating import paths, and modifying the Dockerfile to streamline the build process.

### Codebase organization:

* `api/v1beta1/images.go` renamed to `defaults/images.go` and updated the package name to `defaults`.
* Updated import paths to use the new `defaults` package in various files (`api/v1beta1/automq_webhook.go`, `api/v1beta1/webhook_suite_test.go`, `gen/gen.go`). [[1]](diffhunk://#diff-c41c3e347cf67cb21a4b585802fd2ec0ddbe8c08fa036404b11e7c16e3554a68R21-R22) [[2]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36L23-R31) [[3]](diffhunk://#diff-f18b4bb9cf8a60ec40543e036c8e0f25a8f2e97d9c45108748eec629f0fb4c57L21-R21)

### Default values:

* Replaced references to `DefaultImageName` with `defaults.DefaultImageName` in the `Default` method of `AutoMQ` and related tests. [[1]](diffhunk://#diff-c41c3e347cf67cb21a4b585802fd2ec0ddbe8c08fa036404b11e7c16e3554a68L45-R47) [[2]](diffhunk://#diff-de0d77707877382ea09aa386bee543b689df48ad7c89d6b67657abb7261e3b36L92-R94)
* Updated the `gen/gen.go` file to use `defaults.DefaultImageName` when writing the image name to a file.

### Dockerfile improvements:

* Consolidated the `COPY` commands in the `Dockerfile` to simplify the build process.

### Workflow adjustments:

* Moved the `sealos login` command to a different position within the `push.yml` workflow file to ensure it runs in the correct order.

### Minor changes:

* Fixed an import alias in the `api/v1beta1/zz_generated.deepcopy.go` file.