### PR TITLE
ci(main): add rm sudo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,8 +63,8 @@ jobs:
           go run gen/gen.go ghcr.io/${{ github.repository_owner }}/automq-operator:latest && make info
           cd deploy
           IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/automq-operator-sealos:latest"
-          sudo sealos build -t "${IMAGE_NAME}"-amd64 --platform linux/amd64 . && rm -rf registry
-          sudo sealos build -t "${IMAGE_NAME}"-arm64 --platform linux/arm64 . && rm -rf registry
+          sudo sealos build -t "${IMAGE_NAME}"-amd64 --platform linux/amd64 . && sudo rm -rf registry
+          sudo sealos build -t "${IMAGE_NAME}"-arm64 --platform linux/arm64 . && sudo rm -rf registry
           sudo sealos login -u ${{ github.repository_owner }} -p ${{ secrets.GH_TOKEN }} --debug ghcr.io
           sudo sealos push "${IMAGE_NAME}"-amd64
           sudo sealos push "${IMAGE_NAME}"-arm64


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/push.yml` file. The change ensures that the `rm -rf registry` command is executed with `sudo` privileges.

* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L66-R67): Added `sudo` to the `rm -rf registry` command to ensure it runs with the necessary permissions.