### PR TITLE
ci(main): add deps for job0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,6 +42,7 @@ jobs:
 
   job1:
     runs-on: ubuntu-20.04
+    needs: job0
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ docker-push: ## Push docker image with the manager.
 # - have enabled BuildKit. More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 # - be able to push the image to your registry (i.e. if you do not set a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
 # To adequately provide solutions that are compatible with multiple platforms, you should consider using this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile


### PR DESCRIPTION
This pull request includes changes to the CI workflow and the Docker image build process. The most important changes are the addition of a dependency between jobs in the GitHub Actions workflow and the modification of supported platforms for Docker image builds.

CI workflow improvements:

* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R45): Added a dependency for `job1` to wait for `job0` to complete before starting. (`needs: job0`)

Docker build process updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L94-R94): Reduced the number of supported platforms for Docker image builds by removing `linux/s390x` and `linux/ppc64le` from the `PLATFORMS` variable. (`PLATFORMS ?= linux/arm64,linux/amd64`)