### PR TITLE
feat(main):  add hash from configmap

### DIFF
--- a/internal/controller/automq_status_controller.go
+++ b/internal/controller/automq_status_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	infrav1beta1 "github.com/cuisongliu/automq-operator/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"

--- a/internal/controller/init_contrainer.go
+++ b/internal/controller/init_contrainer.go
@@ -17,10 +17,11 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
+
 	"github.com/cuisongliu/automq-operator/defaults"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"strings"
 )
 
 func sysctlContainer() v1.Container {


### PR DESCRIPTION
This pull request includes several changes to the `internal/controller` package, focusing on improving the handling of context values, imports, and annotations in Kubernetes resources. The most important changes include adding a new context key type, updating import statements, and modifying annotations in the `syncControllerSTS` method.

### Context Handling Enhancements:
* Introduced a new `ctxKey` type to manage context values more effectively in `internal/controller/automq_controller.go`. (`[internal/controller/automq_controller.goR54-R55](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR54-R55)`)
* Added a context value for `hash-configmap` in the `scriptConfigmap` method. (`[internal/controller/automq_controller.goR236](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR236)`)

### Import Statement Updates:
* Updated import statements in `internal/controller/automq_controller.go` to include `time` and `hash`, and removed redundant `time` import. (`[[1]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR23-R29)`, `[[2]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dL40)`)
* Updated import statements in `internal/controller/automq_controller_c.go` to include `strconv` and `strings`, and removed redundant imports. (`[[1]](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R22-R24)`, `[[2]](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5L33-L34)`)
* Added `strings` import in `internal/controller/init_contrainer.go` and removed redundant import. (`[internal/controller/init_contrainer.goR20-L23](diffhunk://#diff-58135be650bae09717c90237ebaa393af4377509ef90d671fc42b6937200c7ddR20-L23)`)

### Annotation Modifications:
* Modified the `syncControllerSTS` method to include `configmap/script-hash` annotation and updated Prometheus annotations. (`[internal/controller/automq_controller_c.goR302-R317](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R302-R317)`)