### PR TITLE
feat(main):  fix chart

### DIFF
--- a/config/samples/infra_v1beta1_automq.yaml
+++ b/config/samples/infra_v1beta1_automq.yaml
@@ -10,8 +10,7 @@ spec:
     secretAccessKey: minio123
     bucket: automq
     enablePathStyle: true
-  broker:
-    replicas: 1
+  nodePort: 32009
   controller:
     replicas: 3
     jvmOptions:

--- a/deploy/charts/automq-operator/templates/deployment.yaml
+++ b/deploy/charts/automq-operator/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           - "-default-qps={{.Values.args.qps}}"
           - "-max-retry-delay={{.Values.args.maxDelay}}"
           - "-min-retry-delay={{.Values.args.minDelay}}"
-          - "-mount-tz=={{.Values.args.mountTZ}}"
+          - "-mount-tz={{.Values.args.mountTZ}}"
           - "-zap-devel=false"
           - "-zap-encoder=console"
           env:


### PR DESCRIPTION
This pull request includes changes to configuration files for `infra_v1beta1_automq.yaml` and `automq-operator` to update node port settings and fix a typo in deployment arguments.

Configuration Updates:

* [`config/samples/infra_v1beta1_automq.yaml`](diffhunk://#diff-2582c308566880ae334ce20487b1b97daf3cf5498a0131daf0be42e3dfe40040L13-R13): Replaced the `broker` section with a `nodePort` setting to specify port `32009`.

Typo Fix:

* [`deploy/charts/automq-operator/templates/deployment.yaml`](diffhunk://#diff-ba495bd2bec5aa9aa4ac748a728bbd9c30f85933891cb7f957ef8c857aae77eeL45-R45): Corrected a typo in the `-mount-tz` argument by removing an extra equals sign.