### PR TITLE
feat(main):  fix index for broker

### DIFF
--- a/internal/controller/automq_controller_b.go
+++ b/internal/controller/automq_controller_b.go
@@ -261,7 +261,7 @@ func (r *AutoMQReconciler) syncBrokerDeploy(ctx context.Context, obj *infrav1bet
 		"--process.roles",
 		"broker",
 		"--node.id",
-		fmt.Sprintf("%d", index),
+		fmt.Sprintf("%d", index+10),
 		"--cluster.id",
 		obj.Spec.ClusterID,
 		"--controller.quorum.voters",


### PR DESCRIPTION
This pull request includes a change to the `syncBrokerDeploy` function in the `internal/controller/automq_controller_b.go` file. The change modifies the way the `node.id` is calculated by adding the number of replicas from the `Controller` specification.

* [`internal/controller/automq_controller_b.go`](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112L264-R264): Modified the `node.id` calculation in the `syncBrokerDeploy` function to add the number of replicas from `obj.Spec.Controller.Replicas`.