### PR TITLE
feat(main):  upgrade automq version

### DIFF
--- a/defaults/images.go
+++ b/defaults/images.go
@@ -17,6 +17,6 @@ limitations under the License.
 package defaults
 
 const (
-	DefaultImageName = "automqinc/automq:1.2.0-rc1"
+	DefaultImageName = "automqinc/automq:1.2.0"
 	BusyboxImageName = "busybox:1.36.1"
 )

--- a/defaults/zz_generated_bindata.go
+++ b/defaults/zz_generated_bindata.go
@@ -82,7 +82,7 @@ func defaultsUpSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "defaults/up.sh", size: 12502, mode: os.FileMode(420), modTime: time.Unix(1728839020, 0)}
+	info := bindataFileInfo{name: "defaults/up.sh", size: 12502, mode: os.FileMode(420), modTime: time.Unix(1728839086, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
This pull request includes updates to the default image versions and metadata in the `defaults` package. The most important changes involve updating the default image name and modifying the metadata for the `up.sh` script.

Updates to default image versions:

* [`defaults/images.go`](diffhunk://#diff-4faf6599e683b0c59b7323a86148be3a9c60629c2d784b72fad7f60084d61234L20-R20): Updated the `DefaultImageName` constant to use the new version "1.2.0" instead of "1.2.0-rc1".

Metadata modifications:

* [`defaults/zz_generated_bindata.go`](diffhunk://#diff-8e14b210d72550b29f8022882c1675741d3562b68a5de85c9a5df3dd277750ddL85-R85): Updated the `modTime` for the `up.sh` script in the `bindataFileInfo` struct to reflect a new timestamp.