### PR TITLE
feat(main):  fix helm config

### DIFF
--- a/api/v1beta1/automq_webhook.go
+++ b/api/v1beta1/automq_webhook.go
@@ -100,6 +100,9 @@ func (r *AutoMQ) ValidateUpdate(old runtime.Object) (admission.Warnings, error) 
 	if r.Spec.ClusterID != mqOld.Spec.ClusterID {
 		return nil, fmt.Errorf("field clusterID is immutable")
 	}
+	if r.Spec.Controller.Replicas != mqOld.Spec.Controller.Replicas {
+		return nil, fmt.Errorf("field controller.replicas is immutable")
+	}
 	if err := validate(r); err != nil {
 		return nil, err
 	}

--- a/deploy/charts/automq-operator/templates/_helpers.tpl
+++ b/deploy/charts/automq-operator/templates/_helpers.tpl
@@ -49,3 +49,40 @@ Selector labels
 app.kubernetes.io/name: {{ include "automq-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+
+{{/*
+Extract the tag from the image repository string.
+Assumes the tag is the part after the last colon `:`.
+If no tag is present, returns an empty string.
+*/}}
+{{- define "automq-operator.getTag" -}}
+  {{- $image := .Values.image -}}
+  {{- $splitImage := splitList ":" $image -}}
+  {{- if eq (len $splitImage) 2 -}}
+    {{- index $splitImage 1 -}}
+  {{- else -}}
+    latest
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Determine the image pull policy.
+If the image tag is 'latest', set the pull policy to 'Always'.
+Otherwise, use the default pull policy from values.yaml.
+*/}}
+{{- define "automq-operator.pullPolicy" -}}
+{{- if eq (include "automq-operator.getTag" .) "latest" -}}
+Always
+{{- else -}}
+IfNotPresent
+{{- end -}}
+{{- end -}}
+
+{{- define "automq-operator.revision" -}}
+{{- if eq (include "automq-operator.getTag" .) "latest" -}}
+{{.Release.Revision}}
+{{- else -}}
+{{ include "automq-operator.getTag" .}}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/automq-operator/templates/deployment.yaml
+++ b/deploy/charts/automq-operator/templates/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "automq-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        operator-revision: {{ include "automq-operator.revision" . }}
       labels:
         {{- include "automq-operator.selectorLabels" . | nindent 8 }}
     spec:
@@ -34,7 +35,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ include "automq-operator.pullPolicy" . }}
           args:
           - "-leader-elect={{.Values.args.leader}}"
           - "-default-burst={{.Values.args.burst}}"

--- a/internal/controller/automq_controller_b.go
+++ b/internal/controller/automq_controller_b.go
@@ -51,7 +51,7 @@ func (r *AutoMQReconciler) cleanBroker(ctx context.Context, obj *infrav1beta1.Au
 		svcc.Name = getAutoMQName(brokerRole, &index)
 		_ = r.Client.Delete(ctx, svcc)
 
-		deploy := &appsv1.StatefulSet{}
+		deploy := &appsv1.Deployment{}
 		deploy.Namespace = obj.Namespace
 		deploy.Name = getAutoMQName(brokerRole, &index)
 		_ = r.Client.Delete(ctx, deploy)
@@ -61,6 +61,11 @@ func (r *AutoMQReconciler) cleanBroker(ctx context.Context, obj *infrav1beta1.Au
 		pvc.Name = getAutoMQName(brokerRole, &index)
 		_ = r.Client.Delete(ctx, pvc)
 	}
+
+	bsvc := &v1.Service{}
+	bsvc.Namespace = obj.Namespace
+	bsvc.Name = getAutoMQName(brokerRole+"-bootstrap", nil)
+	_ = r.Client.Delete(ctx, bsvc)
 	return nil
 }
 
@@ -261,7 +266,7 @@ func (r *AutoMQReconciler) syncBrokerDeploy(ctx context.Context, obj *infrav1bet
 		"--process.roles",
 		"broker",
 		"--node.id",
-		fmt.Sprintf("%d", index+10),
+		fmt.Sprintf("%d", index+obj.Spec.Controller.Replicas),
 		"--cluster.id",
 		obj.Spec.ClusterID,
 		"--controller.quorum.voters",


### PR DESCRIPTION
This pull request introduces several changes to the Helm chart templates and the AutoMQ controller to enhance functionality and improve maintainability. The most important changes include adding new template functions to handle image tags and pull policies, updating deployment annotations, and cleaning up services in the AutoMQ controller.

### Helm Chart Template Enhancements:

* [`deploy/charts/automq-operator/templates/_helpers.tpl`](diffhunk://#diff-af6e8018a94df0a9a4c0f37449b2d11e75413d6a8a3302ff017b4a1132e68850R52-R88): Added functions to extract the image tag, determine the image pull policy based on the tag, and set the revision annotation. (`automq-operator.getTag`, `automq-operator.pullPolicy`, `automq-operator.revision`)

### Deployment Configuration Updates:

* [`deploy/charts/automq-operator/templates/deployment.yaml`](diffhunk://#diff-ba495bd2bec5aa9aa4ac748a728bbd9c30f85933891cb7f957ef8c857aae77eeL16-R20): Updated deployment annotations to include the operator revision and modified the image pull policy to use the new template function. [[1]](diffhunk://#diff-ba495bd2bec5aa9aa4ac748a728bbd9c30f85933891cb7f957ef8c857aae77eeL16-R20) [[2]](diffhunk://#diff-ba495bd2bec5aa9aa4ac748a728bbd9c30f85933891cb7f957ef8c857aae77eeL37-R38)

### AutoMQ Controller Cleanup:

* [`internal/controller/automq_controller_b.go`](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R64-R68): Added code to delete the bootstrap service during the broker cleanup process.