### PR TITLE
feat(main):  fix helm config

### DIFF
--- a/deploy/charts/automq-operator/templates/_helpers.tpl
+++ b/deploy/charts/automq-operator/templates/_helpers.tpl
@@ -81,7 +81,7 @@ IfNotPresent
 
 {{- define "automq-operator.revision" -}}
 {{- if eq (include "automq-operator.getTag" .) "latest" -}}
-{{.Release.Revision}}
+"{{.Release.Revision}}"
 {{- else -}}
 {{ include "automq-operator.getTag" .}}
 {{- end -}}


### PR DESCRIPTION
This pull request includes a small change to the `deploy/charts/automq-operator/templates/_helpers.tpl` file. The change ensures that the `Release.Revision` value is treated as a string by enclosing it in double quotes.

* [`deploy/charts/automq-operator/templates/_helpers.tpl`](diffhunk://#diff-af6e8018a94df0a9a4c0f37449b2d11e75413d6a8a3302ff017b4a1132e68850L84-R84): Enclosed `Release.Revision` in double quotes to ensure it is treated as a string.