### PR TITLE
feat(main):  add envs for jobs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -69,6 +69,8 @@ jobs:
   sync:
     runs-on: ubuntu-20.04
     needs: job1
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,5 +117,7 @@ jobs:
           TAG=${GITHUB_REF#refs/tags/}
           echo ::set-output name=tag_name::${TAG}
       - name: build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           gh issue comment ${{ vars.SEALOS_ISSUE_NUMBER }} --body "/imagebuild_apps automq-operator ${{ steps.prepare.outputs.tag_name }}" --repo ${{ vars.SEALOS_ISSUE_REPO }}


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to ensure that the `GH_TOKEN` is properly set in the environment variables for specific jobs. The most important changes include adding the `GH_TOKEN` environment variable to the `sync` job in the `push.yml` workflow and to the `build` job in the `release.yml` workflow.

Updates to GitHub Actions workflows:

* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R72-R73): Added `GH_TOKEN` to the environment variables for the `sync` job.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R120-R121): Added `GH_TOKEN` to the environment variables for the `build` job.