### PR TITLE
feat(main):  upgrade go version to workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: build
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,9 +12,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: Prepare
         id: prepare
@@ -48,9 +48,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: Verify sealos
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: Prepare
         id: prepare

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: build
         run: |
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: Verify sealos
         run: |
@@ -59,9 +59,9 @@ jobs:
         uses: actions/checkout@master
 
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version-file: go.mod
 
       - name: Verify sealos
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer version of the `setup-go` action and changes the way the Go version is specified. These changes ensure that the workflows are using the latest features and improvements from the `setup-go` action.

Updates to GitHub Actions workflows:

* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L15-R17): Updated `setup-go` action to version `v5` and changed the Go version specification to use `go-version-file: go.mod`.
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L15-R17): Updated `setup-go` action to version `v5` and changed the Go version specification to use `go-version-file: go.mod`. [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L15-R17) [[2]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L51-R53)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L16-R18): Updated `setup-go` action to version `v5` and changed the Go version specification to use `go-version-file: go.mod`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R21): Updated `setup-go` action to version `v5` and changed the Go version specification to use `go-version-file: go.mod`. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-R21) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-R35) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L62-R64)