### PR TITLE
feat(main):  add status logic

### DIFF
--- a/api/v1beta1/automq_types.go
+++ b/api/v1beta1/automq_types.go
@@ -173,11 +173,10 @@ type AutoMQPhase string
 
 // These are the valid phases of node.
 const (
-	AutoMQPending        AutoMQPhase = "Pending"
-	AutoMQError          AutoMQPhase = "Error"
-	AutoMQReady          AutoMQPhase = "Ready"
-	AutoMQInProcess      AutoMQPhase = "InProcess"
-	AutoMQDefaultMessage string      = "success"
+	AutoMQPending   AutoMQPhase = "Pending"
+	AutoMQError     AutoMQPhase = "Error"
+	AutoMQReady     AutoMQPhase = "Ready"
+	AutoMQInProcess AutoMQPhase = "InProcess"
 )
 
 // AutoMQStatus defines the observed state of AutoMQ


### PR DESCRIPTION
This pull request makes several significant enhancements to the `AutoMQ` status reconciliation process, including improving the handling of pod statuses and adding utility functions to streamline the code. The most important changes include updating the `AutoMQ` phase handling, adding a function to get the number of running pods, and importing necessary packages.

Enhancements to `AutoMQ` status reconciliation:

* [`internal/controller/automq_status_controller.go`](diffhunk://#diff-12b298ee6b4900358a4d0589e406c2d8f7da64eab22c4e4086e0a6001d4dbc86R52-R102): Added logic to update the `AutoMQ` status phase to `InProcess` and calculate the number of ready pods. If all required pods are running, the status phase is updated to `Ready`.

Utility functions:

* [`internal/controller/automq_status_controller.go`](diffhunk://#diff-12b298ee6b4900358a4d0589e406c2d8f7da64eab22c4e4086e0a6001d4dbc86R52-R102): Added a new function `getPodRunningNum` to count the number of running pods based on their status and conditions.

Imports:

* [`internal/controller/automq_status_controller.go`](diffhunk://#diff-12b298ee6b4900358a4d0589e406c2d8f7da64eab22c4e4086e0a6001d4dbc86R21-R24): Imported additional packages `fmt`, `k8s.io/api/core/v1`, and `k8s.io/apimachinery/pkg/labels` to support the new functionality.

Minor changes:

* [`api/v1beta1/automq_types.go`](diffhunk://#diff-8fb9499d797e9e6073eb594990a409c444112ce192f26acc4cb88e16bbc8c537L180): Removed the unused constant `AutoMQDefaultMessage`.