### PR TITLE
feat(main):  add bootstrap address

### DIFF
--- a/api/v1beta1/automq_types.go
+++ b/api/v1beta1/automq_types.go
@@ -197,14 +197,17 @@ type AutoMQStatus struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=0
 	ControllerReplicas int32 `json:"controllerReplicas"`
-	// ControllerAddress is the address of the controller
-	// +optional
-	ControllerAddresses []string `json:"controllerAddresses,omitempty"`
 	// BrokerReplicas is the number of broker replicas for the AutoMQ
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=0
 	BrokerReplicas int32 `json:"brokerReplicas"`
+	// ControllerAddress is the address of the controller
+	// +optional
+	ControllerAddresses []string `json:"controllerAddresses,omitempty"`
+	// BootstrapInternalAddress is the address of the bootstrap
+	// +optional
+	BootstrapInternalAddress string `json:"bootstrapInternalAddress,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/infra.cuisongliu.github.com_automqs.yaml
+++ b/config/crd/bases/infra.cuisongliu.github.com_automqs.yaml
@@ -644,6 +644,9 @@ spec:
           status:
             description: AutoMQStatus defines the observed state of AutoMQ
             properties:
+              bootstrapInternalAddress:
+                description: BootstrapInternalAddress is the address of the bootstrap
+                type: string
               brokerReplicas:
                 default: 0
                 description: BrokerReplicas is the number of broker replicas for the

--- a/deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml
+++ b/deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml
@@ -644,6 +644,9 @@ spec:
           status:
             description: AutoMQStatus defines the observed state of AutoMQ
             properties:
+              bootstrapInternalAddress:
+                description: BootstrapInternalAddress is the address of the bootstrap
+                type: string
               brokerReplicas:
                 default: 0
                 description: BrokerReplicas is the number of broker replicas for the

--- a/internal/controller/automq_controller_b.go
+++ b/internal/controller/automq_controller_b.go
@@ -493,5 +493,6 @@ func (r *AutoMQReconciler) syncKafkaBootstrapService(ctx context.Context, obj *i
 		Reason:             "BootstrapServiceReconciling",
 		Message:            fmt.Sprintf("Bootstrap service for the custom resource (%s) has been created", obj.Name),
 	})
+	obj.Status.BootstrapInternalAddress = fmt.Sprintf("%s.%s.svc:%d", getAutoMQName(brokerRole+"-bootstrap", nil), obj.Namespace, 9092)
 	return true
 }


### PR DESCRIPTION
This pull request includes several changes to the AutoMQ project, focusing on adding a new field for the bootstrap internal address and updating related configurations and reconciliations.

### Enhancements to AutoMQ Status:

* [`api/v1beta1/automq_types.go`](diffhunk://#diff-8fb9499d797e9e6073eb594990a409c444112ce192f26acc4cb88e16bbc8c537L200-R210): Added `BootstrapInternalAddress` field to the `AutoMQStatus` struct to store the address of the bootstrap.

### Configuration Updates:

* [`config/crd/bases/infra.cuisongliu.github.com_automqs.yaml`](diffhunk://#diff-e3ffe2350b5eeb12838983f35561eb4882fe76f83687a6f0781f7f64b230f21fR647-R649): Updated the CRD to include the `bootstrapInternalAddress` property in the AutoMQ status.
* [`deploy/charts/automq-operator/crds/infra.cuisongliu.github.com_automqs.yaml`](diffhunk://#diff-e3ffe2350b5eeb12838983f35561eb4882fe76f83687a6f0781f7f64b230f21fR647-R649): Added the `bootstrapInternalAddress` property to the AutoMQ status in the Helm chart CRD.

### Controller Enhancements:

* [`internal/controller/automq_controller_b.go`](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R496): Updated the `syncKafkaBootstrapService` function to set the `BootstrapInternalAddress` in the AutoMQ status.