### PR TITLE
feat(main):  add codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,11 @@ jobs:
       - name: build
         run: |
           make test
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   job1:
     runs-on: ubuntu-20.04
     steps:
@@ -51,6 +56,10 @@ jobs:
       - name: build
         run: |
           sudo make e2e
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   job2:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./api/... --ginkgo.v -v --ginkgo.trace
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./api/... --ginkgo.v -v --ginkgo.trace -coverprofile=coverage.txt
 
 ##@ Build
 
@@ -170,7 +170,7 @@ info:
 
 .PHONY: e2e
 e2e: fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./e2e/... --ginkgo.v -v --ginkgo.trace
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./e2e/... --ginkgo.v -v --ginkgo.trace -coverprofile=coverage.txt
 
 
 bindata:


### PR DESCRIPTION
This pull request includes updates to the CI workflow and the `Makefile` to integrate code coverage reporting using Codecov. The most important changes are the addition of steps to upload test results to Codecov in the GitHub Actions workflow and the modification of test commands in the `Makefile` to generate coverage reports.

### CI Workflow Enhancements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R26-R30): Added steps to upload results to Codecov in the `build` and `e2e` jobs. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R26-R30) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R59-R62)

### Makefile Updates:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L65-R65): Modified the `test` and `e2e` targets to include the `-coverprofile=coverage.txt` flag for generating coverage reports. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L65-R65) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L173-R173)