### PR TITLE
feat(main):  add update version scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Dockerfile.cross
 artifacts
 
 config/kubeconfigs
+replace_content.txt

--- a/README.md
+++ b/README.md
@@ -74,21 +74,19 @@ sealos run labring/kafka-ui:v0.7.1
 #### For release version
 
 1.  Using sealos images install operator
-
+    <!--automq-operator release sealos begin-->
     ```shell
     sealos run ghcr.io/cuisongliu/automq-operator-sealos:v0.0.4
     ```
-
+    <!--automq-operator release sealos end-->   
 2.  Using helm chart install operator
-
+    <!--automq-operator release begin-->
     ```shell
-    wget https://github.com/cuisongliu/automq-operator/releases/download/v0.0.4/automq-operator-v0.0.4-sealos.tgz
-    mkdir -p automq-operator
-    tar -zxvf automq-operator-v0.0.4-sealos.tgz -C automq-operator
-    cd automq-operator/deploy
-    bash install.sh
+    wget -q https://github.com/cuisongliu/automq-operator/releases/download/v0.0.4/automq-operator-v0.0.4-sealos.tgz
+    mkdir -p automq-operator && tar -zxvf automq-operator-v0.0.4-sealos.tgz -C automq-operator
+    cd automq-operator/deploy && bash install.sh
     ```
-
+    <!--automq-operator release sealos end-->
 ### Install AutoMQ
 
 ```shell

--- a/gen/version/gen.go
+++ b/gen/version/gen.go
@@ -34,8 +34,8 @@ func main() {
 	_ = os.MkdirAll("deploy/images/shim", 0755)
 	_ = os.WriteFile("deploy/images/shim/image.txt", []byte(defaults.DefaultImageName), 0755)
 	_ = os.WriteFile("deploy/images/shim/busybox.txt", []byte(defaults.BusyboxImageName), 0755)
-	cmd1 := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\image: %s' deploy/charts/automq-operator/values.yaml", imageName)
-	if err := execCmd("bash", "-c", cmd1); err != nil {
+	cmdUpgradeImageName := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\image: %s' deploy/charts/automq-operator/values.yaml", imageName)
+	if err := execCmd("bash", "-c", cmdUpgradeImageName); err != nil {
 		fmt.Printf("execCmd error %v", err)
 		os.Exit(1)
 	}
@@ -48,11 +48,24 @@ func main() {
 	if shotVersion == "latest" {
 		shotVersion = "0.0.0"
 	}
-	cmd2 := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\version: %s' deploy/charts/automq-operator/Chart.yaml", shotVersion)
-	if err := execCmd("bash", "-c", cmd2); err != nil {
+	cmdUpgradeChartVersion := fmt.Sprintf("sed -i '/#replace_by_makefile/!b;n;c\\version: %s' deploy/charts/automq-operator/Chart.yaml", shotVersion)
+	if err := execCmd("bash", "-c", cmdUpgradeChartVersion); err != nil {
 		fmt.Printf("execCmd error %v", err)
 		os.Exit(1)
 	}
+
+	cmdUpgradeReadme := fmt.Sprintf("scripts/release_tag.sh v%s", shotVersion)
+	if err := execCmd("bash", "-c", cmdUpgradeReadme); err != nil {
+		fmt.Printf("execCmd error %v", err)
+		os.Exit(1)
+	}
+
+	cmdUpgradeReadmeSealos := fmt.Sprintf("scripts/release_tag_sealos.sh v%s", shotVersion)
+	if err := execCmd("bash", "-c", cmdUpgradeReadmeSealos); err != nil {
+		fmt.Printf("execCmd error %v", err)
+		os.Exit(1)
+	}
+
 	fmt.Printf("update image success")
 }
 

--- a/scripts/release_tag.sh
+++ b/scripts/release_tag.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TAG=${1}
+
+if [ -z "$TAG" ]; then
+    echo "Error: No version number provided."
+    exit 1
+fi
+VERSION=${TAG##*v}
+
+START_MARKER="<!--automq-operator release begin-->"
+END_MARKER="<!--automq-operator release end-->"
+
+
+echo "    \`\`\`shell
+    wget -q https://github.com/cuisongliu/automq-operator/releases/download/v${VERSION}/automq-operator-v${VERSION}-sealos.tgz
+    mkdir -p automq-operator && tar -zxvf automq-operator-v${VERSION}-sealos.tgz -C automq-operator
+    cd automq-operator/deploy && bash install.sh
+    \`\`\`" > replace_content.txt
+
+awk -v start="$START_MARKER" -v end="$END_MARKER" -v newfile="replace_content.txt" '
+BEGIN {printing=1}
+$0 ~ start {print;system("cat " newfile);printing=0}
+$0 ~ end {printing=1}
+printing' README.md > temp.txt && mv temp.txt README.md

--- a/scripts/release_tag_sealos.sh
+++ b/scripts/release_tag_sealos.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+TAG=${1}
+
+if [ -z "$TAG" ]; then
+    echo "Error: No version number provided."
+    exit 1
+fi
+VERSION=${TAG##*v}
+
+START_MARKER="<!--automq-operator release sealos begin-->"
+END_MARKER="<!--automq-operator release sealos end-->"
+
+
+echo "    \`\`\`shell
+    sealos run ghcr.io/cuisongliu/automq-operator-sealos:v${VERSION}
+    \`\`\`" > replace_content.txt
+
+awk -v start="$START_MARKER" -v end="$END_MARKER" -v newfile="replace_content.txt" '
+BEGIN {printing=1}
+$0 ~ start {print;system("cat " newfile);printing=0}
+$0 ~ end {printing=1}
+printing' README.md > temp.txt && mv temp.txt README.md


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `gen/version/gen.go` files, introducing new scripts to automate version updates and streamline the installation process. The most important changes include adding markers in the `README.md` for automated content replacement, renaming variables for clarity in `gen/version/gen.go`, and adding new scripts for updating the `README.md` based on version tags.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R89): Added markers for automated content replacement to streamline the process of updating installation instructions.

### Code Enhancements:

* [`gen/version/gen.go`](diffhunk://#diff-63347093637fdbb722ef4edf1d5ccf686ce1f55d786a9e9e2c3ef30eddd1f439L37-R38): Renamed variables `cmd1` and `cmd2` to `cmdUpgradeImageName` and `cmdUpgradeChartVersion` for better clarity. Added commands to update the `README.md` using new scripts. [[1]](diffhunk://#diff-63347093637fdbb722ef4edf1d5ccf686ce1f55d786a9e9e2c3ef30eddd1f439L37-R38) [[2]](diffhunk://#diff-63347093637fdbb722ef4edf1d5ccf686ce1f55d786a9e9e2c3ef30eddd1f439L51-R68)

### New Scripts:

* [`scripts/release_tag.sh`](diffhunk://#diff-5eef7752f7b527996a6d9f941321980a824bb1c2eb10722f74ed220dead55070R1-R25): Added a script to update the `README.md` with the latest version of the AutoMQ operator installation instructions.
* [`scripts/release_tag_sealos.sh`](diffhunk://#diff-2b09bb9666ce18d622884ed8b3ae1c13c81bc9aa44b7c04f82969d8b2da79217R1-R23): Added a script to update the `README.md` with the latest version of the AutoMQ operator installation instructions for Sealos.