### PR TITLE
feat(main):  fix error for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ sealos run labring/kafka-ui:v0.7.1
     mkdir -p automq-operator && tar -zxvf automq-operator-v0.0.4-sealos.tgz -C automq-operator
     cd automq-operator/deploy && bash install.sh
     ```
-    <!--automq-operator release sealos end-->
+    <!--automq-operator release end-->
 ### Install AutoMQ
 
 ```shell


### PR DESCRIPTION
This pull request includes a minor change to the `README.md` file. The change involves updating a comment to remove the reference to `sealos`.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L89-R89): Updated the comment from `<!--automq-operator release sealos end-->` to `<!--automq-operator release end-->`.