### PR TITLE
feat(main):  add apis node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-  job2:
+  job1:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -48,9 +48,16 @@ jobs:
           cd deploy
           sudo sealos build -t ghcr.io/${{ github.repository_owner }}/automq-operator-sealos:latest .
 
-  job1:
+  job2:
     runs-on: ubuntu-20.04
     steps:
+      - name: Before freeing up disk space
+        run: |
+          echo "Before freeing up disk space"
+          echo "=============================================================================="
+          df -hT
+          echo "=============================================================================="
+
       - name: Checkout
         uses: actions/checkout@master
 
@@ -62,7 +69,7 @@ jobs:
       - name: Verify sealos
         run: |
           curl -sfL https://raw.githubusercontent.com/labring/sealos/v5.0.0/scripts/install.sh | sh -s v5.0.0  labring/sealos
-      - name: prune os
+      - name: install k8s and apps
         run: |
           sudo systemctl unmask containerd
           sudo systemctl unmask docker
@@ -74,7 +81,10 @@ jobs:
           sudo rm -rf /run/containerd/containerd.sock
           sudo sealos run labring/kubernetes:v1.27.7 
           sudo sealos run labring/helm:v3.9.4 labring/calico:v3.26.5  labring/openebs:v3.9.0 labring/cert-manager:v1.14.6
-          sudo sealos run labring/minio:RELEASE.2024-01-11T07-46-16Z labring/kube-prometheus-stack:v0.63.0  labring/kafka-ui:v0.7.1
+          sudo sealos run labring/minio:RELEASE.2024-01-11T07-46-16Z labring/kube-prometheus-stack:v0.63.0  
+          sudo sealos run labring/kafka-ui:v0.7.1
+          sleep 10
+          sudo kubectl get pods -A --show-labels
       - name: build
         run: |
           sudo make e2e

--- a/e2e/automq_cluster_controller_test.go
+++ b/e2e/automq_cluster_controller_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"time"
+
+	infrav1beta1 "github.com/cuisongliu/automq-operator/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("automq_controller", func() {
+	Context("automq_controller cr tests", func() {
+		ctx := context.Background()
+		namespaceName := "automq-operator"
+		namespace := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespaceName,
+				Namespace: namespaceName,
+			},
+		}
+		automq := &infrav1beta1.AutoMQ{}
+		automq.Name = "automq-s1"
+		automq.Namespace = namespaceName
+		automq.Spec.ClusterID = "rZdE0DjZSrqy96PXrMUZVw"
+
+		BeforeEach(func() {
+			By("Creating the Namespace to perform the tests")
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).To(Not(HaveOccurred()))
+			By("Setting the NAMESPACE_NAME ENV VAR which stores the Operand image")
+			err = os.Setenv("NAMESPACE_NAME", namespaceName)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("Update Endpoint", func() {
+			By("creating the custom resource for the automq")
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(automq), automq)
+			if err != nil && errors.IsNotFound(err) {
+				// Let's mock our custom resource at the same way that we would
+				// apply on the cluster the manifest under config/samples
+				automq.Spec.S3.Endpoint = "http://minio.minio.svc.cluster.local:9000"
+				automq.Spec.S3.Bucket = "ko3"
+				automq.Spec.S3.AccessKeyID = "admin"
+				automq.Spec.S3.SecretAccessKey = "minio123"
+				automq.Spec.S3.Region = "us-east-1"
+				automq.Spec.S3.EnablePathStyle = true
+				automq.Spec.Controller.Replicas = 1
+				automq.Spec.Broker.Replicas = 3
+				automq.Spec.NodePort = 32009
+				err = k8sClient.Create(ctx, automq)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+		})
+		AfterEach(func() {
+			By("removing the custom resource for the automq")
+			found := &infrav1beta1.AutoMQ{}
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(automq), found)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() error {
+				return k8sClient.Delete(context.TODO(), found)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			// TODO(user): Attention if you improve this code by adding other context test you MUST
+			// be aware of the current delete namespace limitations.
+			// More info: https://book.kubebuilder.io/reference/envtest.html#testing-considerations
+			By("Deleting the Namespace to perform the tests")
+			_ = k8sClient.Delete(ctx, namespace)
+
+			By("Removing the Image ENV VAR which stores the Operand image")
+			_ = os.Unsetenv("NAMESPACE_NAME")
+		})
+	})
+
+})

--- a/e2e/httplib.go
+++ b/e2e/httplib.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	httpl "net/http"
+	"time"
+)
+
+func httpTransport() httpl.Transport {
+	return httpl.Transport{
+		Proxy: httpl.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   200,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   15 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Minute,
+		DisableCompression:    false,
+		DisableKeepAlives:     false,
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+	}
+}
+
+type RespReturn struct {
+	Data   []byte
+	Code   int32
+	Error  error
+	Header httpl.Header
+}
+
+func RestHttpApi(ctx context.Context, url, method string, body io.Reader, timeout int32, fns ...func(h httpl.Header)) RespReturn {
+	if timeout == 0 {
+		timeout = 60
+	}
+	trans := httpTransport()
+	// https://github.com/golang/go/issues/13801
+	client := &httpl.Client{
+		Transport: &trans,
+	}
+	defer client.CloseIdleConnections()
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(int64(timeout)*int64(time.Second)))
+	defer cancel()
+	req, _ := httpl.NewRequestWithContext(ctx, method, url, body)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("User-agent", "RealHttpConnector")
+	req.Header.Set("Connection", "keep-alive")
+	for _, f := range fns {
+		f(req.Header)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return RespReturn{
+			Data:   nil,
+			Code:   500,
+			Error:  err,
+			Header: nil,
+		}
+	}
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return RespReturn{
+			Data:   nil,
+			Code:   500,
+			Error:  err,
+			Header: nil,
+		}
+	}
+	return RespReturn{
+		Data:   data,
+		Code:   int32(resp.StatusCode),
+		Error:  err,
+		Header: resp.Header,
+	}
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -17,9 +17,10 @@ limitations under the License.
 package e2e
 
 import (
-	"github.com/cuisongliu/logger"
 	"net"
 	"sort"
+
+	"github.com/cuisongliu/logger"
 )
 
 func LocalIP(addrs *[]net.Addr) string {

--- a/internal/controller/automq_apis.go
+++ b/internal/controller/automq_apis.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 cuisongliu@qq.com.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	v1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func APIRegistry(ctx context.Context, k8sClient client.Client) {
+	setupLog := ctrl.Log.WithName("setup")
+	setupLog.Info("cache sync success")
+	router := gin.Default()
+	router.GET("/api/v1/nodes/:name", func(c *gin.Context) {
+		name := c.Param("name")
+		node := &v1.Node{}
+		node.Name = name
+		if noe := k8sClient.Get(ctx, client.ObjectKeyFromObject(node), node); noe != nil {
+			c.JSON(500, gin.H{"message": noe.Error()})
+			return
+		}
+		nodeIP := ""
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == v1.NodeInternalIP {
+				nodeIP = addr.Address
+				break
+			}
+		}
+		if nodeIP == "" {
+			c.JSON(500, gin.H{"message": "node ip not found"})
+			return
+		}
+		c.String(200, nodeIP)
+	})
+	router.Run(":9090")
+}


### PR DESCRIPTION
This pull request includes significant changes to the `automq-operator` project, focusing on workflow improvements, refactoring the main application, and enhancing end-to-end tests. The most important changes include renaming jobs in the GitHub Actions workflow, refactoring the main application to use a centralized API registry, and adding new end-to-end tests.

### Workflow Improvements:
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L31-R31): Renamed `job2` to `job1` and vice versa, added a step to log disk space before freeing it up, and modified the job to install Kubernetes and applications instead of pruning the OS. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L31-R31) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L51-R60) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L65-R72) [[4]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L77-R87)

### Application Refactoring:
* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L21-L31): Removed direct Gin router setup in favor of using the `APIRegistry` function from the `controller` package. [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L21-L31) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L133-R129)
* [`internal/controller/automq_apis.go`](diffhunk://#diff-244292790fe44a1a930c157882a2ab4c17da2d2d2d807fb9226dadaba0678bb1R1-R53): Added a new file to handle API registration using Gin.

### End-to-End Testing Enhancements:
* [`e2e/automq_cluster_controller_test.go`](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20R1-R96): Added a new end-to-end test for the `automq_controller` to verify custom resource creation and cleanup.
* [`e2e/automq_cluster_test.go`](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08L22-R33): Refactored existing tests to include component status checks for Minio, Cert-Manager, Prometheus, and Kafka-UI. [[1]](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08L22-R33) [[2]](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08L60-R165) [[3]](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08R195-R198) [[4]](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08R211-R214)
* [`e2e/httplib.go`](diffhunk://#diff-acb26ce3c8a00c0de0ebb3019586423364ef04a02cac774f518a03a0d172a0f5R1-R99): Added a new utility for making HTTP requests in end-to-end tests.
* [`e2e/utils.go`](diffhunk://#diff-04a1accd1c12dafffe8d3ecc43a623cd0bf22d03d3561f7e04e296e64962048eL20-R23): Minor import reorganization.