### PR TITLE
feat(main):  add test for automq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,8 @@ jobs:
           sudo sealos run labring/minio:RELEASE.2024-01-11T07-46-16Z labring/kube-prometheus-stack:v0.63.0  
           sudo sealos run labring/kafka-ui:v0.7.1
           sleep 10
-          sudo kubectl get pods -A --show-labels
+          sudo kubectl get pods -A
+          sudo kubectl get svc -A
       - name: build
         run: |
           sudo make e2e

--- a/e2e/automq_cluster_test.go
+++ b/e2e/automq_cluster_test.go
@@ -212,6 +212,8 @@ var _ = BeforeSuite(func() {
 	go func() {
 		controller.APIRegistry(context.Background(), k8sClient)
 	}()
+	err = os.Setenv("NAMESPACE_NAME", "default")
+	Expect(err).To(Not(HaveOccurred()))
 })
 
 var _ = AfterSuite(func() {

--- a/internal/controller/automq_apis.go
+++ b/internal/controller/automq_apis.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+
 	"github.com/gin-gonic/gin"
 	v1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/internal/controller/automq_controller_b.go
+++ b/internal/controller/automq_controller_b.go
@@ -100,7 +100,7 @@ func (r *AutoMQReconciler) syncBrokerScale(ctx context.Context, obj *infrav1beta
 
 func (r *AutoMQReconciler) syncBrokers(ctx context.Context, obj *infrav1beta1.AutoMQ) bool {
 	conditionType := "SyncBrokerReady"
-
+	log := log.FromContext(ctx)
 	// 1. sync pvc
 	// 2. sync deploy
 	// 3. sync svc
@@ -115,6 +115,7 @@ func (r *AutoMQReconciler) syncBrokers(ctx context.Context, obj *infrav1beta1.Au
 				Reason:             "BrokerPVCReconciling",
 				Message:            fmt.Sprintf("Failed to create pvc for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create pvc for the custom resource", "name", obj.Name, "role", brokerRole)
 			return true
 		}
 		if err := r.syncBrokerService(ctx, obj, int32(i)); err != nil {
@@ -125,6 +126,7 @@ func (r *AutoMQReconciler) syncBrokers(ctx context.Context, obj *infrav1beta1.Au
 				Reason:             "BrokerServiceReconciling",
 				Message:            fmt.Sprintf("Failed to create service for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create service for the custom resource", "name", obj.Name, "role", brokerRole)
 			return true
 		}
 		if err := r.syncBrokerDeploy(ctx, obj, int32(i)); err != nil {
@@ -135,6 +137,7 @@ func (r *AutoMQReconciler) syncBrokers(ctx context.Context, obj *infrav1beta1.Au
 				Reason:             "BrokerSTSReconciling",
 				Message:            fmt.Sprintf("Failed to create deploy for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create deploy for the custom resource", "name", obj.Name, "role", brokerRole)
 			return true
 		}
 	}

--- a/internal/controller/automq_controller_c.go
+++ b/internal/controller/automq_controller_c.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -90,7 +91,7 @@ func (r *AutoMQReconciler) syncControllersScale(ctx context.Context, obj *infrav
 
 func (r *AutoMQReconciler) syncControllers(ctx context.Context, obj *infrav1beta1.AutoMQ) bool {
 	conditionType := "SyncControllerReady"
-
+	log := log.FromContext(ctx)
 	// 1. sync pvc
 	// 2. sync deploy
 	// 3. sync svc
@@ -105,6 +106,7 @@ func (r *AutoMQReconciler) syncControllers(ctx context.Context, obj *infrav1beta
 				Reason:             "ControllerPVCReconciling",
 				Message:            fmt.Sprintf("Failed to create pvc for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create pvc for the custom resource (%s)", obj.Name, "role", controllerRole)
 			return true
 		}
 		if err := r.syncControllerDeploy(ctx, obj, int32(i)); err != nil {
@@ -115,6 +117,7 @@ func (r *AutoMQReconciler) syncControllers(ctx context.Context, obj *infrav1beta
 				Reason:             "ControllerSTSReconciling",
 				Message:            fmt.Sprintf("Failed to create deploy for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create deploy for the custom resource (%s)", obj.Name, "role", controllerRole)
 			return true
 		}
 		if err := r.syncControllerService(ctx, obj, int32(i)); err != nil {
@@ -125,6 +128,7 @@ func (r *AutoMQReconciler) syncControllers(ctx context.Context, obj *infrav1beta
 				Reason:             "ControllerServiceReconciling",
 				Message:            fmt.Sprintf("Failed to create service for the custom resource (%s): (%s)", obj.Name, err),
 			})
+			log.Error(err, "Failed to create service for the custom resource (%s)", obj.Name, "role", controllerRole)
 			return true
 		}
 	}


### PR DESCRIPTION
This pull request includes various improvements and fixes to the `automq_controller` and related test files to enhance logging, error handling, and test coverage. The most important changes include adding detailed error logs, updating test cases, and modifying the namespace for the tests.

### Error Handling and Logging Improvements:
* [`internal/controller/automq_controller.go`](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR224): Added detailed error logs in multiple functions to provide more context when failures occur. [[1]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR224) [[2]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR234) [[3]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR246) [[4]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR271) [[5]](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dR299)
* [`internal/controller/automq_controller_b.go`](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R118): Enhanced logging for PVC, service, and deployment creation failures. [[1]](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R118) [[2]](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R129) [[3]](diffhunk://#diff-09f114397ebb3777fed61911b0dc26e4b7317c7ca855bb99052fd3f634028112R140)
* [`internal/controller/automq_controller_c.go`](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R109): Improved logging for controller PVC, service, and deployment creation failures. [[1]](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R109) [[2]](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R120) [[3]](diffhunk://#diff-d245a0c3141d1e204d50f91a2f2453511e1f4a157f48d9df14a0f5452d1415b5R131)

### Test Case Updates:
* [`e2e/automq_cluster_controller_test.go`](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20L36-R42): Updated the namespace name and added new test cases for resource creation, reconciliation, and status checks. [[1]](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20L36-R42) [[2]](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20L47-R69) [[3]](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20L75-R195)
* [`e2e/automq_cluster_test.go`](diffhunk://#diff-37db78e8ee6e2b21c91cad61d932cb24679ad30a6a641b99a6385fcbbeabca08R215-R216): Set the `NAMESPACE_NAME` environment variable in the `BeforeSuite` function.

### Minor Code Enhancements:
* [`internal/controller/automq_controller.go`](diffhunk://#diff-518ef86c8cca5a146f361950294aa1dfdfd9bfad14b9c8250befa4a56f6f8b9dL175-R177): Added index logging in the reconcile loop for better traceability.
* [`e2e/automq_cluster_controller_test.go`](diffhunk://#diff-f7f21d522fb8ca2fe99f9e0ce82a1152d5bcd16b80c534544d26bd6af7938a20R21-R29): Added necessary imports for new test cases.
* [`internal/controller/automq_apis.go`](diffhunk://#diff-244292790fe44a1a930c157882a2ab4c17da2d2d2d807fb9226dadaba0678bb1R21): Added a blank line for better code readability.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L87-R88): Added a command to get services in all namespaces to the testing workflow.