### PR TITLE
feat(main): fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          gh release create "${{ github.ref }}" -t "${{ steps.prepare.outputs.tag_name }} Release" --generate-notes --draft
+          gh release create "${{ github.ref }}" -t "${{ steps.prepare.outputs.tag_name }}" --generate-notes --prerelease
           gh release upload "${{ github.ref }}" artifacts/*
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow for releases. The change modifies the release creation command to mark releases as pre-releases instead of drafts.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L79-R79): Changed the `gh release create` command to use the `--prerelease` flag instead of the `--draft` flag.